### PR TITLE
Create LoopToken without extending from ERC20

### DIFF
--- a/contracts/LoopToken.sol
+++ b/contracts/LoopToken.sol
@@ -1,10 +1,35 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+contract LoopToken {
+    mapping(address => uint256) public _balances;
 
-contract LoopToken is ERC20 {
-    constructor(uint256 initialSupply) ERC20("LoopToken", "LT") {
-        _mint(msg.sender, initialSupply);
+    string public _name;
+    string public _symbol;
+    uint8 public _decimals;
+    uint256 public _totalSupply;
+
+    event Transfer(address indexed from, address indexed to, uint256 amount);
+
+    constructor(string memory name_, string memory symbol_, uint256 totalSupply_) {
+        _name = name_;
+        _symbol = symbol_;
+        _totalSupply = totalSupply_;
+        _decimals = 18;
+
+         _balances[msg.sender] = _totalSupply;
+        emit Transfer(address(0), msg.sender, _totalSupply);
+    }
+
+    function transfer(address to, uint256 amount) public returns (bool) {
+        require(to != address(0), "Transfer from the zero address");
+        uint256 ownerBalance = _balances[msg.sender];
+        require(ownerBalance >= amount, "Insufficient funds");
+        _balances[msg.sender] = ownerBalance - amount;
+        _balances[to] += amount;
+
+        emit Transfer(msg.sender, to, amount);
+
+        return true;
     }
 }


### PR DESCRIPTION
Fui leyendo de [acá](https://ethereum.org/en/developers/docs/standards/tokens/erc-20/) sobre ERC-20:
>If a Smart Contract implements the following methods and events it can be called an ERC-20 Token Contract and, once deployed, it will be responsible to keep track of the created tokens on Ethereum.

Particularmente de estas listas de métodos y eventos:

**Métodos**
```solidity
function name() public view returns (string)
function symbol() public view returns (string)
function decimals() public view returns (uint8)
function totalSupply() public view returns (uint256)
function balanceOf(address _owner) public view returns (uint256 balance)
function transfer(address _to, uint256 _value) public returns (bool success)
function transferFrom(address _from, address _to, uint256 _value) public returns (bool success)
function approve(address _spender, uint256 _value) public returns (bool success)
function allowance(address _owner, address _spender) public view returns (uint256 remaining)
```

**Eventos**
```solidity
event Transfer(address indexed _from, address indexed _to, uint256 _value)
event Approval(address indexed _owner, address indexed _spender, uint256 _value)
```

No tengo las implementaciones de `transferFrom()`, `approve()`, `allowance()` ni el event `Approval` todavía.

También me fui guiando con el [ERC20](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol) de OpenZeppelin, chusmeando sus imports y demás.

---

Las dudas que me fueron surgiendo son:
- Está bien que `name`, `symbol`, `decimals` y `totalSupply` se los pase al constructor?
- En las funciones que declaré para poder acceder a `name`, `symbol`, `decimals` y `totalSupply`, usé `public view` solamente, y veo que en OpenZeppelin les agregan `virtual override`. El `virtual` es para que quien implemente su `ERC20`, las pueda overridear; y el `override` quiere decir que esa función está overrideando a su 'función base'?

---

Voy a seguir con las implementaciones que dije más arriba que me faltan. Habíamos hablado algo más para esta versión 'a mano' del `LT`? 

_EDIT: creo que habíamos dicho que no íbamos a implementar `transferFrom`, `approve` y `allowance`, no?_

(Ah, comenté lo que habías codeado vos usando `ERC20`, no lo quería borrar, ni tener 2 files diferentes para el token.)